### PR TITLE
Update Wiki link to external URL

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,7 +13,7 @@
                     <a href="/schedule" class="hover:text-blue-600 dark:hover:text-blue-400">Schedule</a>
                     <a href="/resources" class="hover:text-blue-600 dark:hover:text-blue-400">Resources</a>
                     <a href="/staff" class="hover:text-blue-600 dark:hover:text-blue-400">Staff</a>
-                    <a href="/wiki" class="hover:text-blue-600 dark:hover:text-blue-400">Wiki</a>
+                    <a href="https://illinoiscs.wiki" target="_blank" rel="noopener noreferrer" class="hover:text-blue-600 dark:hover:text-blue-400">Wiki</a>
                     <!-- <a href="/about" class="hover:text-blue-600 dark:hover:text-blue-400">About</a> -->
                 </div>
             </div>


### PR DESCRIPTION
Open https://illinoiscs.wiki in new tab when clicking on wiki tab